### PR TITLE
fix(storefront): BCTHEME-735 sync bc-core with themes changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Draft
+- Update path to theme bundle file in amp iframe that fixes showing options without SKUs on the PDP. [#1](https://github.com/bigcommerce/themes-lib-core/pull/1)
 ## [3.9.10] - 2021-05-28
 - Remove cookie notification, now handled by platform
 

--- a/assets/js/theme/core/amp/AmpProductUtils.js
+++ b/assets/js/theme/core/amp/AmpProductUtils.js
@@ -58,7 +58,10 @@ export default class ProductUtils {
       this.cartAddAlert.clear();
       this.cartOptionAlert.clear();
 
-      utils.api.productAttributes.optionChange(this.productId, $form.serialize(), (err, response) => {
+      // product template should be passed as a string
+      const productTemplate = this.options.template && typeof this.options.template === 'string' ? this.options.template : null;
+
+      utils.api.productAttributes.optionChange(this.productId, $form.serialize(), productTemplate, (err, response) => {
         const viewModel = this._getViewModel(this.$el);
         const data = response ? response.data : {};
 

--- a/config/schema.json
+++ b/config/schema.json
@@ -594,16 +594,16 @@
         },
         {
           "type": "select",
-          "label": "Ranged price format",
+          "label": "Price format",
           "id": "price_range_display",
           "options": [
             {
               "value": "both",
-              "label": "Show lowest and highest price"
+              "label": "Show price ranges for products with variants"
             },
             {
               "value": "lowest",
-              "label": "Show lowest price"
+              "label": "Show default product price for all products"
             }
           ]
         },

--- a/install.sh
+++ b/install.sh
@@ -8,7 +8,7 @@ if [ -z "$1" ]; then
 fi
 
 # Destination path doesn't look like a theme
-if [ ! -f "$1/.stencil" ]; then
+if [ ! -f "$1/config.stencil.json" ]; then
   echo "No .stencil file found in destination directory. Halting."
   exit 1
 fi

--- a/lang/en.json
+++ b/lang/en.json
@@ -7,7 +7,8 @@
         "categories": "Categories",
         "contact": "Contact",
         "pages": "Pages",
-        "sitemap_title": "Sitemap"
+        "sitemap_title": "Sitemap",
+        "powered_by": "Powered by {powered_by}"
       },
       "header": {
         "account": "Account",
@@ -139,7 +140,7 @@
         "amount": "Amount",
         "preview": "Preview Theme",
         "theme": "Gift Certificate Theme",
-        "custom_range": "(Value must be between {min} and {max} and contian no special characters. Example: 50)",
+        "custom_range": "(Value must be between {min} and {max} and contain no special characters. Example: 50)",
         "agree": "I understand that Gift Certificates expire after {days, plural, one {1 day} other {# days}}",
         "agree2": "I agree that Gift Certificates are nonrefundable",
         "submit_value": "Add Gift Certificate to Cart",

--- a/templates/core/amp/common/footer.html
+++ b/templates/core/amp/common/footer.html
@@ -54,7 +54,7 @@
       {{#block 'amp-social'}} {{/block}}
     {{/if}}
     {{#if theme_credits}}
-      <p>{{theme_name}} theme by <a href="https://pixelunion.net" target="_blank" rel="nofollow">Pixel Union</a>, Powered by <a href="http://bigcommerce.com" rel="nofollow">BigCommerce</a></p>
+    <p>{{{lang 'core.amp.footer.powered_by' powered_by='<a href="https://bigcommerce.com" rel="nofollow">BigCommerce</a>'}}}</p>
     {{/if}}
     {{#if store_copyright}}
       <p>&copy; {{settings.store_name}}</p>

--- a/templates/core/amp/layout/amp-iframe.html
+++ b/templates/core/amp/layout/amp-iframe.html
@@ -25,7 +25,7 @@
 
     {{#block "page"}} {{/block}}
 
-    <script src="{{cdn '/assets/js/bundle.js'}}"></script>
+    <script src="{{cdn 'assets/dist/theme-bundle.main.js'}}"></script>
 
     <script>
       // Exported in app.js

--- a/templates/core/amp/products/product-options.html
+++ b/templates/core/amp/products/product-options.html
@@ -25,7 +25,7 @@
         {{> core/products/event}}
       {{/if}}
 
-      {{#if product.show_quantity_input}}
+      {{#if theme_settings.show_product_quantity_box}}
         <div class="add-to-cart-quantity-container">
           <div class="form-field" data-product-quantity>
             <label class="form-label">


### PR DESCRIPTION
#### What?

This PR updates BC-Core  and fixes path's being used in amp iframe for theme's bundle. It fixes issue with PxU Themes AMP pages show options without SKUs once Control Panel setting is set to hide OOS. 

**NOTE:** to scale this change to PxU themes we need to update them via BC-core.

**What to pay attention to:**
1.  `install.sh` used old stencil file to detect targeted Theme. It's been replaced with `config.stencil.json` according to new stencil-cli versions.
2. added a second param **productTemplate** for `init method` in AmpProductUtils.js. It will be used to return part of the product options payload as rendered HTML once product's option has been changed by User. In this way we can provide any suitable template within each Theme.
3. Updated path to themes' bundle to `assets/dist/theme-bundle.main.js` since previous path is outdated and caused an [issue](https://jira.bigcommerce.com/browse/BCTHEME-735) with showing options without SKUs (out of stock setting in control panel required)AMP pages.

#### Requirements

- [x] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation
- [BCTHEME-735](https://jira.bigcommerce.com/browse/BCTHEME-735)
