### PR TITLE
chore: DATA-11172 Populate data tags despite of data_tag_enabled setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Draft
 - Update path to theme bundle file in amp iframe that fixes showing options without SKUs on the PDP. [#1](https://github.com/bigcommerce/themes-lib-core/pull/1)
+- Populate data tags despite of data_tag_enabled setting  [#2](https://github.com/bigcommerce/themes-lib-core/pull/2)
+
 ## [3.9.10] - 2021-05-28
 - Remove cookie notification, now handled by platform
 

--- a/templates/core/amp/category/product-item.html
+++ b/templates/core/amp/category/product-item.html
@@ -1,14 +1,12 @@
 <article
   class="amp-grid-item amp-product-grid-item"
-  {{#if data_tag_enabled}}
-    data-event-type="product"
-    data-entity-id="{{id}}"
-    data-name="{{title}}"
-    data-product-category="{{#each category}}{{#if @last}}{{this}}{{else}}{{this}}, {{/if}}{{/each}}"
-    data-product-brand="{{brand.name}}"
-    data-product-price="{{#if price.with_tax}}{{price.with_tax.value}}{{else}}{{price.without_tax.value}}{{/if}}"
-    data-product-variant="single-product-option"
-  {{/if}}
+  data-event-type="product"
+  data-entity-id="{{id}}"
+  data-name="{{title}}"
+  data-product-category="{{#each category}}{{#if @last}}{{this}}{{else}}{{this}}, {{/if}}{{/each}}"
+  data-product-brand="{{brand.name}}"
+  data-product-price="{{#if price.with_tax}}{{price.with_tax.value}}{{else}}{{price.without_tax.value}}{{/if}}"
+  data-product-variant="single-product-option"
 >
   {{#or price.non_sale_price_with_tax price.non_sale_price_without_tax}}
     {{#unless out_of_stock_message}}

--- a/templates/core/amp/category/product-listing.html
+++ b/templates/core/amp/category/product-listing.html
@@ -17,7 +17,6 @@
         non_sale_price_label=../theme_settings.non-sale-price-label
         sale_price_label=../theme_settings.sale-price-label
         price_label=../theme_settings.price-label
-        data_tag_enabled=../settings.data_tag_enabled
         event="list"
         position=(add @index 1)
       }}

--- a/templates/core/amp/products/product-details.html
+++ b/templates/core/amp/products/product-details.html
@@ -1,14 +1,12 @@
 <section
   class="amp-product-details"
-  {{#if settings.data_tag_enabled}}
-    data-event-type="product"
-    data-entity-id="{{product.id}}"
-    data-name="{{product.title}}"
-    data-product-category="{{#each product.category}}{{#if @last}}{{this}}{{else}}{{this}}, {{/if}}{{/each}}"
-    data-product-brand="{{product.brand.name}}"
-    data-product-price="{{#if product.price.with_tax}}{{product.price.with_tax.value}}{{else}}{{product.price.without_tax.value}}{{/if}}"
-    data-product-variant="single-product-option"
-  {{/if}}
+  data-event-type="product"
+  data-entity-id="{{product.id}}"
+  data-name="{{product.title}}"
+  data-product-category="{{#each product.category}}{{#if @last}}{{this}}{{else}}{{this}}, {{/if}}{{/each}}"
+  data-product-brand="{{product.brand.name}}"
+  data-product-price="{{#if product.price.with_tax}}{{product.price.with_tax.value}}{{else}}{{product.price.without_tax.value}}{{/if}}"
+  data-product-variant="single-product-option"
 >
   {{#or price.non_sale_price_with_tax price.non_sale_price_without_tax}}
     <div class="product-badge product-badge-sale">

--- a/templates/core/amp/products/product-form.html
+++ b/templates/core/amp/products/product-form.html
@@ -16,7 +16,7 @@
     <a
       class="button amp-button-primary"
       href="{{product.cart_url}}"
-      {{#if settings.data_tag_enabled}}data-event-type="product-click"{{/if}}
+      data-event-type="product-click"
     >
       {{#if product.pre_order}}
         <span class="button-text">


### PR DESCRIPTION
## What? [DATA-11172](https://bigcommercecloud.atlassian.net/browse/DATA-11172)
Previously we populated data tags only when Universal Google Analytics was enabled. Since it's now going away there will be no way for merchants to enable these data tags on their stores. As some merchants were using them to build their custom analytics integrations, it has been decided to populate data tags for all merchants despite of `data-tag_enable` setting, so that they can proceed using it even when Universal Google Analytics is gone.

## Tickets / Documentation

Add links to any relevant tickets and documentation.
- Jira ticket [DATA-11172](https://bigcommercecloud.atlassian.net/browse/DATA-11172)
- [Original github issue](https://github.com/bigcommerce/cornerstone/issues/2195)


[DATA-11172]: https://bigcommercecloud.atlassian.net/browse/DATA-11172?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DATA-11172]: https://bigcommercecloud.atlassian.net/browse/DATA-11172?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ